### PR TITLE
Run yaml safe load instead of plain load.

### DIFF
--- a/train4.py
+++ b/train4.py
@@ -131,7 +131,7 @@ if __name__ == '__main__':
                         datefmt='%m/%d/%Y %H:%M:%S', level=logging.DEBUG)
 
     with open(args.config, 'r') as f:
-        config = yaml.load(f)
+        config = yaml.safe_load(f)
     # EXPER_PATH from settings.py
     output_dir = os.path.join(EXPER_PATH, args.exper_name)
     os.makedirs(output_dir, exist_ok=True)


### PR DESCRIPTION
To fix the following error: 
```
# python3 train4.py train_base configs/magicpoint_shapes_pair.yaml magicpoint_synth --eval
Traceback (most recent call last):
  File "train4.py", line 134, in <module>
    config = yaml.load(f)
TypeError: load() missing 1 required positional argument: 'Loader'
```